### PR TITLE
FIX Ensure parent exists when generating links

### DIFF
--- a/code/pages/MediaPage.php
+++ b/code/pages/MediaPage.php
@@ -363,6 +363,9 @@ class MediaPage extends SiteTree {
 	public function Link($action = null) {
 
 		$parent = $this->getParent();
+		if (!$parent) {
+			return '';
+		}
 		$date = ($parent->URLFormatting !== '-') ? $this->dbObject('Date')->Format($parent->URLFormatting) : '';
 		$link = $parent->Link() . "{$date}{$this->URLSegment}/";
 		if($action) {
@@ -378,6 +381,9 @@ class MediaPage extends SiteTree {
 	public function AbsoluteLink($action = null) {
 
 		$parent = $this->getParent();
+		if (!$parent) {
+			return '';
+		}
 		$date = ($parent->URLFormatting !== '-') ? $this->dbObject('Date')->Format($parent->URLFormatting) : '';
 		$link = $parent->AbsoluteLink() . "{$date}{$this->URLSegment}/";
 		if($action) {


### PR DESCRIPTION
Prevents issues when the parent node is null during link generation (eg
generating live link where parent is still unpublished)
