### PR TITLE
fix(MediaHolder): Fixed bug where array_merge would break the keys

### DIFF
--- a/code/pages/MediaHolder.php
+++ b/code/pages/MediaHolder.php
@@ -43,10 +43,8 @@ class MediaHolder extends Page {
 			$fields->addFieldToTab('Root.Main', DropdownField::create(
 				'MediaTypeID',
 				'Media Type',
-				array_merge(array(
-					0 => ''
-				), MediaType::get()->map()->toArray())
-			), 'Title');
+				MediaType::get()->map()->toArray()
+			)->setHasEmptyDefault(true), 'Title');
 
 		// Allow customisation of the media URL format.
 


### PR DESCRIPTION
 Fixed bug where array_merge would break the keys of MediaType.

The array_merge would turn:
Array
(
    [5] => 2 Column
    [1] => Blog
    [2] => Event
    [3] => News
    [4] => Publication
)

into:

Array
(
    [0] =>
    [1] => 2 Column
    [2] => Blog
    [3] => Event
    [4] => News
    [5] => Publication
)

Meaning that the set MediaType would be incorrect.
