### PR TITLE
fix(phpDoc): This fixes errors when using a PHP Static analyzer (like PHPStan) as it sees "@return data list" as returning the type "data".

### DIFF
--- a/src/pages/MediaHolder.php
+++ b/src/pages/MediaHolder.php
@@ -2,18 +2,20 @@
 
 namespace nglasl\mediawesome;
 
+use Page;
 use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\Forms\GridField\GridFieldConfig_RecordEditor;
 use SilverStripe\Forms\GridField\GridFieldDeleteAction;
 use SilverStripe\Forms\ReadonlyField;
+use SilverStripe\ORM\DataList;
 
 /**
  *	Displays media holder/page children, with optional date/tag filters.
  *	@author Nathan Glasl <nathan@symbiote.com.au>
  */
 
-class MediaHolder extends \Page {
+class MediaHolder extends Page {
 
 	private static $table_name = 'MediaHolder';
 
@@ -110,7 +112,7 @@ class MediaHolder extends \Page {
 	/**
 	 *	Retrieve any `MediaHolder` children of this `MediaHolder`.
 	 *
-	 *	@return data list
+	 *	@return DataList|MediaHolder[]
 	 */
 
 	public function getMediaHolderChildren() {
@@ -121,9 +123,8 @@ class MediaHolder extends \Page {
 	/**
 	 *	Retrieve any `MediaPage` children of this `MediaHolder`.
 	 *
-	 *	@return data list
+	 *	@return DataList|MediaPage[]
 	 */
-
 	public function getMediaPageChildren() {
 
 		return $this->AllChildren()->filter('ClassName', MediaPage::class);


### PR DESCRIPTION
fix(phpDoc): This fixes errors when using a PHP Static analyzer (like PHPStan) as it sees "@return data list" as returning the type "data".

**Notes:**
- The namespace either needs to be "used" at the top or have the full namespace in the phpDoc comment: `@return \SilverStripe\ORM\DataList|MediaHolder[]`
- For returning a DataList of [x] type, you use "union types", so the typehint is basically saying "This is a DataList and also an array of MediaHolder's". You can see this in use in silverstripe cms here as well: https://github.com/silverstripe/silverstripe-cms/blob/4/code/Model/SiteTree.php#L103