### PR TITLE
fix(MediaPage): Links to ignore non-string actions

### DIFF
--- a/src/pages/MediaPage.php
+++ b/src/pages/MediaPage.php
@@ -413,7 +413,7 @@ class MediaPage extends \Page {
 			$parent->Link(),
 			"{$date}{$this->URLSegment}/"
 		);
-		if($action) {
+		if($action && is_string($action)) {
 			$join[] = "{$action}/";
 		}
 		$link = Controller::join_links($join);
@@ -432,7 +432,7 @@ class MediaPage extends \Page {
 		}
 		$date = ($parent->URLFormatting !== '-') ? $this->dbObject('Date')->Format($parent->URLFormatting ?: 'y/MM/dd/') : '';
 		$link = $parent->AbsoluteLink() . "{$date}{$this->URLSegment}/";
-		if($action) {
+		if($action && is_string($action)) {
 			$link .= "{$action}/";
 		}
 		return $link;


### PR DESCRIPTION
When a link is constructed via `ContentController::Link()` it passes `true` as the action to:

> force the expanded link to be returned so that form methods and similar will function properly

In this case it's slapping '/1/' onto links that are invoked via a template (because true = 1).

https://github.com/silverstripe/silverstripe-cms/blob/4/code/Controllers/ContentController.php#L95-L105